### PR TITLE
Fix AMI owner ID

### DIFF
--- a/examples/couchbase-ami/couchbase.json
+++ b/examples/couchbase-ami/couchbase.json
@@ -100,7 +100,7 @@
     "type": "shell",
     "inline": [
       "sudo mkdir -p /opt/gruntwork",
-      "git clone --branch v0.0.2 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons",
+      "git clone --branch v0.0.4 https://github.com/gruntwork-io/bash-commons.git /tmp/bash-commons",
       "sudo cp -r /tmp/bash-commons/modules/bash-commons/src /opt/gruntwork/bash-commons"
     ]
   },{

--- a/examples/couchbase-cluster-mds/main.tf
+++ b/examples/couchbase-cluster-mds/main.tf
@@ -448,7 +448,7 @@ module "iam_policies_sync_gateway" {
 
 data "aws_ami" "coubase_ubuntu_example" {
   most_recent = true
-  owners      = ["738755648600"] # Gruntwork
+  owners      = ["562637147889"] # Gruntwork
 
   filter {
     name   = "virtualization-type"

--- a/examples/couchbase-cluster-simple-dns-tls/main.tf
+++ b/examples/couchbase-cluster-simple-dns-tls/main.tf
@@ -275,7 +275,7 @@ data "aws_acm_certificate" "load_balancer" {
 
 data "aws_ami" "coubase_ubuntu_example" {
   most_recent = true
-  owners      = ["738755648600"] # Gruntwork
+  owners      = ["562637147889"] # Gruntwork
 
   filter {
     name   = "virtualization-type"

--- a/examples/couchbase-multi-datacenter-replication/main.tf
+++ b/examples/couchbase-multi-datacenter-replication/main.tf
@@ -326,7 +326,7 @@ module "iam_policies_replica" {
 
 data "aws_ami" "coubase_ubuntu_example_primary" {
   most_recent = true
-  owners      = ["738755648600"] # Gruntwork
+  owners      = ["562637147889"] # Gruntwork
 
   filter {
     name   = "virtualization-type"
@@ -353,7 +353,7 @@ data "aws_ami" "coubase_ubuntu_example_primary" {
 
 data "aws_ami" "coubase_ubuntu_example_replica" {
   most_recent = true
-  owners      = ["738755648600"] # Gruntwork
+  owners      = ["562637147889"] # Gruntwork
 
   filter {
     name   = "virtualization-type"

--- a/main.tf
+++ b/main.tf
@@ -230,7 +230,7 @@ module "iam_policies" {
 
 data "aws_ami" "coubase_ubuntu_example" {
   most_recent = true
-  owners      = ["738755648600"] # Gruntwork
+  owners      = ["562637147889"] # Gruntwork
 
   filter {
     name   = "virtualization-type"


### PR DESCRIPTION
The examples were using the wrong account ID; instead our AMI account, they were pointing to a test account, and all AMIs were recently deleted from that account, breaking all the examples. This PR updates the examples to the proper account ID.

Fixes #28.