### PR TITLE
Fix domain name lookup using tags

### DIFF
--- a/examples/couchbase-cluster-simple-dns-tls/main.tf
+++ b/examples/couchbase-cluster-simple-dns-tls/main.tf
@@ -310,4 +310,5 @@ data "template_file" "ami_id" {
 
 data "aws_route53_zone" "load_balancer" {
   name = "${var.domain_name}."
+  tags = "${var.domain_name_tags}"
 }

--- a/examples/couchbase-cluster-simple-dns-tls/variables.tf
+++ b/examples/couchbase-cluster-simple-dns-tls/variables.tf
@@ -70,3 +70,9 @@ variable "sync_gateway_load_balancer_port" {
   description = "The port the load balancer should listen on for Sync Gateway requests."
   default     = 4984
 }
+
+variable "domain_name_tags" {
+  description = "Tags the hosted zone must have. Useful if you have multiple hosted zones with the same domain name."
+  type        = "map"
+  default     = {}
+}

--- a/test/couchbase_single_cluster_dns_tls_test.go
+++ b/test/couchbase_single_cluster_dns_tls_test.go
@@ -1,16 +1,20 @@
 package test
 
 import (
-	"testing"
-	"path/filepath"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
+	"path/filepath"
+	"testing"
 )
 
 // This domain name is registered in the Gruntwork Phx DevOps account. It also has ACM certs in all regions.
 const domainNameForTest = "gruntwork.in"
+
+// We have multiple hosted zones in the Gruntwork Phx DevOps account with the same domain name. This helps
+// filter them down to the real public hosted zone for domainNameForTest.
+var domainNameTags = map[string]string{"original": "true"}
 
 func TestIntegrationCouchbaseCommunitySingleClusterDnsTlsUbuntu(t *testing.T) {
 	t.Parallel()
@@ -42,7 +46,7 @@ func testCouchbaseSingleClusterDnsTls(t *testing.T, osName string, edition strin
 		aws.DeleteAmi(t, awsRegion, amiId)
 	})
 
-	defer test_structure.RunTestStage(t,"logs", func() {
+	defer test_structure.RunTestStage(t, "logs", func() {
 		terraformOptions := test_structure.LoadTerraformOptions(t, couchbaseSingleClusterDnsTlsDir)
 		awsRegion := test_structure.LoadString(t, couchbaseSingleClusterDnsTlsDir, savedAwsRegion)
 		testStageLogs(t, terraformOptions, couchbaseClusterVarName, awsRegion)
@@ -58,6 +62,7 @@ func testCouchbaseSingleClusterDnsTls(t *testing.T, osName string, edition strin
 			Vars: map[string]interface{}{
 				"ami_id":                amiId,
 				"domain_name":           domainNameForTest,
+				"domain_name_tags":      domainNameTags,
 				couchbaseClusterVarName: formatCouchbaseClusterName("single-cluster", uniqueId),
 			},
 			EnvVars: map[string]string{


### PR DESCRIPTION
We now have several hosted zones in our test AWS account with the same domain name, so to make sure we're picking the proper one, this PR updates the code to filter hosted zones by tags in addition to domain name.