### PR TITLE
Add option to pass security group tags into couchbase-cluster module.

### DIFF
--- a/modules/couchbase-cluster/main.tf
+++ b/modules/couchbase-cluster/main.tf
@@ -86,6 +86,8 @@ resource "aws_security_group" "lc_security_group" {
   lifecycle {
     create_before_destroy = true
   }
+
+  tags = "${var.security_group_tags}"
 }
 
 resource "aws_security_group_rule" "allow_ssh_inbound" {

--- a/modules/couchbase-cluster/variables.tf
+++ b/modules/couchbase-cluster/variables.tf
@@ -160,3 +160,9 @@ variable "tags" {
   #   }
   # ]
 }
+
+variable "security_group_tags" {
+  description = "Custom tags to apply to the security group."
+  type        = "map"
+  default     = {}
+}


### PR DESCRIPTION
Addresses https://github.com/gruntwork-io/terraform-aws-couchbase/issues/36

I followed the pattern that is used elsewhere for setting Load Balancer tags, except here I need to use the var name security_group_tags because `tags` is already used in the couchbase cluster module