### PR TITLE
fix typos in terraform scripts for ami image

### DIFF
--- a/examples/couchbase-cluster-mds/main.tf
+++ b/examples/couchbase-cluster-mds/main.tf
@@ -446,7 +446,7 @@ module "iam_policies_sync_gateway" {
 # to try these examples out, but we recommend you build your own AMIs for production use.
 # ---------------------------------------------------------------------------------------------------------------------
 
-data "aws_ami" "coubase_ubuntu_example" {
+data "aws_ami" "couchbase_ubuntu_example" {
   most_recent = true
   owners      = ["562637147889"] # Gruntwork
 
@@ -472,7 +472,7 @@ data "aws_ami" "coubase_ubuntu_example" {
 }
 
 data "template_file" "ami_id" {
-  template = "${var.ami_id == "" ? data.aws_ami.coubase_ubuntu_example.id : var.ami_id}"
+  template = "${var.ami_id == "" ? data.aws_ami.couchbase_ubuntu_example.id : var.ami_id}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/couchbase-cluster-simple-dns-tls/main.tf
+++ b/examples/couchbase-cluster-simple-dns-tls/main.tf
@@ -273,7 +273,7 @@ data "aws_acm_certificate" "load_balancer" {
 # to try these examples out, but we recommend you build your own AMIs for production use.
 # ---------------------------------------------------------------------------------------------------------------------
 
-data "aws_ami" "coubase_ubuntu_example" {
+data "aws_ami" "couchbase_ubuntu_example" {
   most_recent = true
   owners      = ["562637147889"] # Gruntwork
 
@@ -299,7 +299,7 @@ data "aws_ami" "coubase_ubuntu_example" {
 }
 
 data "template_file" "ami_id" {
-  template = "${var.ami_id == "" ? data.aws_ami.coubase_ubuntu_example.id : var.ami_id}"
+  template = "${var.ami_id == "" ? data.aws_ami.couchbase_ubuntu_example.id : var.ami_id}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/couchbase-multi-datacenter-replication/main.tf
+++ b/examples/couchbase-multi-datacenter-replication/main.tf
@@ -324,7 +324,7 @@ module "iam_policies_replica" {
 # specified. This makes it easier to try these examples out, but we recommend you build your own AMIs for production use.
 # ---------------------------------------------------------------------------------------------------------------------
 
-data "aws_ami" "coubase_ubuntu_example_primary" {
+data "aws_ami" "couchbase_ubuntu_example_primary" {
   most_recent = true
   owners      = ["562637147889"] # Gruntwork
 
@@ -351,7 +351,7 @@ data "aws_ami" "coubase_ubuntu_example_primary" {
   provider = "aws.primary"
 }
 
-data "aws_ami" "coubase_ubuntu_example_replica" {
+data "aws_ami" "couchbase_ubuntu_example_replica" {
   most_recent = true
   owners      = ["562637147889"] # Gruntwork
 
@@ -379,11 +379,11 @@ data "aws_ami" "coubase_ubuntu_example_replica" {
 }
 
 data "template_file" "ami_id_primary" {
-  template = "${var.ami_id_primary == "" ? data.aws_ami.coubase_ubuntu_example_primary.id : var.ami_id_primary}"
+  template = "${var.ami_id_primary == "" ? data.aws_ami.couchbase_ubuntu_example_primary.id : var.ami_id_primary}"
 }
 
 data "template_file" "ami_id_replica" {
-  template = "${var.ami_id_replica == "" ? data.aws_ami.coubase_ubuntu_example_replica.id : var.ami_id_replica}"
+  template = "${var.ami_id_replica == "" ? data.aws_ami.couchbase_ubuntu_example_replica.id : var.ami_id_replica}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I took a look at running tests, but...

a) Costs money
b) Not sure which `dep` tool you're using but if its [this one](https://golang.github.io/dep/docs/new-project.html) doesn't like not having `$GOPATH/src` and will not pull deps.  Any reason why you don't just use the newer, built-in vendoring now and ditch the 3rd party tool?

