### PR TITLE
Add ubuntu18.04 to examples and test

### DIFF
--- a/examples/couchbase-ami/couchbase.json
+++ b/examples/couchbase-ami/couchbase.json
@@ -25,6 +25,25 @@
     },
     "ssh_username": "ubuntu"
   },{
+    "name": "ubuntu-18-ami",
+    "ami_name": "{{user `base_ami_name`}}-ubuntu-18-example-{{isotime | clean_ami_name}}",
+    "ami_description": "An Ubuntu 18.04 AMI that has Couchbase installed.",
+    "instance_type": "t2.micro",
+    "region": "{{user `aws_region`}}",
+    "type": "amazon-ebs",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "architecture": "x86_64",
+        "name": "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-*",
+        "block-device-mapping.volume-type": "gp2",
+        "root-device-type": "ebs"
+      },
+      "owners": ["099720109477"],
+      "most_recent": true
+    },
+    "ssh_username": "ubuntu"
+  },{
     "name": "amazon-linux-ami",
     "ami_name": "{{user `base_ami_name`}}-amazon-linux-example-{{isotime | clean_ami_name}}",
     "ami_description": "An Amazon Linux 2 AMI that has Couchbase installed.",
@@ -54,6 +73,16 @@
       "/sys/fs/cgroup": "/sys/fs/cgroup"
     }
   },{
+    "name": "ubuntu-18-docker",
+    "type": "docker",
+    "image": "gruntwork/ubuntu-test:18.04",
+    "commit": true,
+    "run_command": ["-d", "-i", "-t", "{{.Image}}", "/sbin/init"],
+    "privileged": true,
+    "volumes": {
+      "/sys/fs/cgroup": "/sys/fs/cgroup"
+    }
+  },{
     "name": "amazon-linux-docker",
     "type": "docker",
     "image": "gruntwork/amazon-linux-test:2017.12",
@@ -75,10 +104,10 @@
     "type": "shell",
     "pause_before": "5s",
     "inline": [
-      "DEBIAN_FRONTEND=noninteractive apt-get update",
-      "apt-get install -y git"
+      "apt-get update",
+      "DEBIAN_FRONTEND=noninteractive apt-get install -y git"
     ],
-    "only": ["ubuntu-docker"]
+    "only": ["ubuntu-docker", "ubuntu-18-docker"]
   },{
     "type": "shell",
     "pause_before": "30s",
@@ -91,11 +120,11 @@
     "type": "shell",
     "pause_before": "30s",
     "inline": [
-      "DEBIAN_FRONTEND=noninteractive sudo apt-get update",
-      "sudo apt-get install -y jq curl git python-pip",
+      "sudo apt-get update",
+      "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y jq curl git python-pip",
       "sudo -H pip install --upgrade awscli"
     ],
-    "only": ["ubuntu-ami"]
+    "only": ["ubuntu-ami", "ubuntu-18-ami"]
   },{
     "type": "shell",
     "inline": [
@@ -126,6 +155,11 @@
     "repository": "gruntwork/couchbase-ubuntu-test",
     "tag": "latest",
     "only": ["ubuntu-docker"]
+  },{
+    "type": "docker-tag",
+    "repository": "gruntwork/couchbase-ubuntu-18-test",
+    "tag": "latest",
+    "only": ["ubuntu-18-docker"]
   },{
     "type": "docker-tag",
     "repository": "gruntwork/couchbase-amazon-linux-test",

--- a/modules/couchbase-cluster/main.tf
+++ b/modules/couchbase-cluster/main.tf
@@ -162,6 +162,13 @@ resource "aws_iam_instance_profile" "instance_profile" {
   lifecycle {
     create_before_destroy = true
   }
+
+  # IAM objects take time to propagate. This leads to subtle eventual consistency bugs where the ASG cannot be created
+  # because the IAM instance profile does not exist. We add a 15 second wait here to give the IAM instance profile a
+  # chance to propagate within AWS.
+  provisioner "local-exec" {
+    command = "echo 'Sleeping for 15 seconds to wait for IAM instance profile to be created'; sleep 15"
+  }
 }
 
 resource "aws_iam_role" "instance_role" {
@@ -173,6 +180,13 @@ resource "aws_iam_role" "instance_role" {
   # when you try to do a terraform destroy.
   lifecycle {
     create_before_destroy = true
+  }
+
+  # IAM objects take time to propagate. This leads to subtle eventual consistency bugs where the ASG cannot be created
+  # because the IAM role does not exist. We add a 15 second wait here to give the IAM role a chance to propagate within
+  # AWS.
+  provisioner "local-exec" {
+    command = "echo 'Sleeping for 15 seconds to wait for IAM role to be created'; sleep 15"
   }
 }
 

--- a/modules/install-couchbase-server/disable-thp
+++ b/modules/install-couchbase-server/disable-thp
@@ -9,7 +9,7 @@
 # Short-Description: Disable THP
 # Description:       disables Transparent Huge Pages (THP) on boot
 ### END INIT INFO
-          
+
 case $1 in
 start)
   if [ -d /sys/kernel/mm/transparent_hugepage ]; then

--- a/modules/install-couchbase-server/install-couchbase-server
+++ b/modules/install-couchbase-server/install-couchbase-server
@@ -84,7 +84,7 @@ function install_couchbase_on_ubuntu {
   sudo apt-get install -y python-httplib2
 
   log_info "Downloading Couchbase from $url to $filepath"
-  if ! curl --location --silent --fail --show-error -o "$dpkg_name" "$url"; then
+  if [[ "$(curl --location --silent --fail --show-error -o "$dpkg_name" -w "%{http_code}" "$url")" == "404" ]]; then
     log_warn "Failed to get Couchbase from $url. Trying $fallback_url."
     curl --location --silent --fail --show-error -o "$dpkg_name" "$fallback_url"
   fi

--- a/modules/install-couchbase-server/install-couchbase-server
+++ b/modules/install-couchbase-server/install-couchbase-server
@@ -76,7 +76,7 @@ function install_couchbase_on_ubuntu {
   # that the vast majority of Couchbase server builds do not have official deb packages for 18.04. That said, the 16.04
   # package has been verified to work, so we will fallback to using that if the 18.04 build is not available.
   local readonly fallback_filepath="couchbase-server-${edition}_${version}-ubuntu16.04_amd64.deb"
-  local readonly fallback_url="https://packages.couchbase.com/releases/$version/$filepath"
+  local readonly fallback_url="https://packages.couchbase.com/releases/$version/$fallback_filepath"
 
   log_info "Installing Couchbase dependencies"
   sudo DEBIAN_FRONTEND=noninteractive apt-get update

--- a/modules/install-couchbase-server/install-couchbase-server
+++ b/modules/install-couchbase-server/install-couchbase-server
@@ -68,15 +68,24 @@ function install_couchbase_on_ubuntu {
 
   log_info "Installing Couchbase $version ($edition edition) on Ubuntu"
 
-  local readonly filepath="couchbase-server-${edition}_${version}-ubuntu16.04_amd64.deb"
+  local readonly ubuntu_version="$(lsb_release -r -s)"
+  local readonly filepath="couchbase-server-${edition}_${version}-ubuntu${ubuntu_version}_amd64.deb"
   local readonly url="https://packages.couchbase.com/releases/$version/$filepath"
+
+  # NOTE: Couchbase only started publishing Ubuntu 18.04 deb packages for Enterprise edition version 6.0.2, which means
+  # that the vast majority of Couchbase server builds do not have official deb packages for 18.04. That said, the 16.04
+  # package has been verified to work, so we will fallback to using that if the 18.04 build is not available.
+  local readonly fallback_filepath="couchbase-server-${edition}_${version}-ubuntu16.04_amd64.deb"
+  local readonly fallback_url="https://packages.couchbase.com/releases/$version/$filepath"
 
   log_info "Installing Couchbase dependencies"
   sudo DEBIAN_FRONTEND=noninteractive apt-get update
   sudo apt-get install -y python-httplib2
 
   log_info "Downloading Couchbase from $url to $filepath"
-  curl --location --silent --fail --show-error -O "$url"
+  curl --location --silent --fail --show-error -O "$url" \
+    || log_warn "Failed to get Couchbase from $url. Trying $fallback_url." \
+       && curl --location --silent --fail --show-error -O "$fallback_url"
 
   os_validate_checksum "$filepath" "$checksum" "$checksum_type"
 
@@ -248,7 +257,7 @@ function install {
 
   log_info "Starting Couchbase install..."
 
-  if os_is_ubuntu "16.04"; then
+  if os_is_ubuntu "16.04" || os_is_ubuntu "18.04"; then
     install_couchbase_on_ubuntu "$edition" "$version" "$checksum" "$checksum_type"
   elif os_is_amazon_linux "2"; then
     install_couchbase_on_amazon_linux "$edition" "$version" "$checksum" "$checksum_type"

--- a/modules/install-couchbase-server/install-couchbase-server
+++ b/modules/install-couchbase-server/install-couchbase-server
@@ -65,10 +65,11 @@ function install_couchbase_on_ubuntu {
   local readonly version="$2"
   local readonly checksum="$3"
   local readonly checksum_type="$4"
-
-  log_info "Installing Couchbase $version ($edition edition) on Ubuntu"
-
   local readonly ubuntu_version="$(lsb_release -r -s)"
+  local readonly dpkg_name="couchbase-server.deb"
+
+  log_info "Installing Couchbase $version ($edition edition) on Ubuntu $ubuntu_version"
+
   local readonly filepath="couchbase-server-${edition}_${version}-ubuntu${ubuntu_version}_amd64.deb"
   local readonly url="https://packages.couchbase.com/releases/$version/$filepath"
 
@@ -83,23 +84,21 @@ function install_couchbase_on_ubuntu {
   sudo apt-get install -y python-httplib2
 
   log_info "Downloading Couchbase from $url to $filepath"
-  if curl --location --silent --fail --show-error -O "$url"; then
-    os_validate_checksum "$filepath" "$checksum" "$checksum_type"
-  else
+  if ! curl --location --silent --fail --show-error -o "$dpkg_name" "$url"; then
     log_warn "Failed to get Couchbase from $url. Trying $fallback_url."
-    curl --location --silent --fail --show-error -O "$fallback_url"
-    os_validate_checksum "$fallback_filepath" "$checksum" "$checksum_type"
+    curl --location --silent --fail --show-error -o "$dpkg_name" "$fallback_url"
   fi
 
+  os_validate_checksum "$dpkg_name" "$checksum" "$checksum_type"
 
   # Install Couchbase, but configure it to NOT start on boot. This allows the run-couchbase-server script to configure
   # Couchbase, including what ports to use, and THEN boot it up.
-  log_info "Installing Couchbase from $filepath"
-  sudo INSTALL_DONT_START_SERVER=1 dpkg -i "$filepath"
+  log_info "Installing Couchbase from $dpkg_name"
+  sudo INSTALL_DONT_START_SERVER=1 dpkg -i "$dpkg_name"
   sudo systemctl disable couchbase-server
 
-  log_info "Cleaning up $filepath"
-  rm -f "$filepath"
+  log_info "Cleaning up $dpkg_name"
+  rm -f "$dpkg_name"
 }
 
 function install_couchbase_on_amazon_linux {

--- a/modules/install-couchbase-server/install-couchbase-server
+++ b/modules/install-couchbase-server/install-couchbase-server
@@ -45,7 +45,7 @@ function print_usage {
   echo
   echo "Usage: install-couchbase-server [options]"
   echo
-  echo "This script can be used to install Couchbase Server and its dependencies. This script has been tested with Ubuntu 16.04 and Amazon Linux 2."
+  echo "This script can be used to install Couchbase Server and its dependencies. This script has been tested with Ubuntu 16.04, 18.04, and Amazon Linux 2."
   echo
   echo "Options:"
   echo
@@ -147,7 +147,7 @@ function disable_transparent_huge_pages {
   elif os_is_amazon_linux; then
     sudo chkconfig disable-thp on
   else
-    log_error "This script only supports Ubuntu 16.04 and Amazon Linux 2."
+    log_error "This script only supports Ubuntu 16.04, 18.04, and Amazon Linux 2."
     exit 1
   fi
 }

--- a/modules/install-couchbase-server/install-couchbase-server
+++ b/modules/install-couchbase-server/install-couchbase-server
@@ -83,11 +83,14 @@ function install_couchbase_on_ubuntu {
   sudo apt-get install -y python-httplib2
 
   log_info "Downloading Couchbase from $url to $filepath"
-  curl --location --silent --fail --show-error -O "$url" \
-    || log_warn "Failed to get Couchbase from $url. Trying $fallback_url." \
-       && curl --location --silent --fail --show-error -O "$fallback_url"
+  if curl --location --silent --fail --show-error -O "$url"; then
+    os_validate_checksum "$filepath" "$checksum" "$checksum_type"
+  else
+    log_warn "Failed to get Couchbase from $url. Trying $fallback_url."
+    curl --location --silent --fail --show-error -O "$fallback_url"
+    os_validate_checksum "$fallback_filepath" "$checksum" "$checksum_type"
+  fi
 
-  os_validate_checksum "$filepath" "$checksum" "$checksum_type"
 
   # Install Couchbase, but configure it to NOT start on boot. This allows the run-couchbase-server script to configure
   # Couchbase, including what ports to use, and THEN boot it up.

--- a/modules/install-sync-gateway/install-sync-gateway
+++ b/modules/install-sync-gateway/install-sync-gateway
@@ -48,7 +48,7 @@ function print_usage {
   echo
   echo "Usage: install-sync-gateway [options]"
   echo
-  echo "This script can be used to install Couchbase Sync Gateway and its dependencies. This script has been tested with Ubuntu 16.04 and Amazon Linux 2."
+  echo "This script can be used to install Couchbase Sync Gateway and its dependencies. This script has been tested with Ubuntu 16.04, 18.04, and Amazon Linux 2."
   echo
   echo "Options:"
   echo
@@ -257,12 +257,12 @@ function install {
 
   log_info "Starting Sync Gateway install..."
 
-  if os_is_ubuntu "16.04"; then
+  if os_is_ubuntu "16.04" || os_is_ubuntu "18.04"; then
     install_sync_gateway_on_ubuntu "$edition" "$version" "$checksum" "$checksum_type"
   elif os_is_amazon_linux "2"; then
     install_sync_gateway_on_amazon_linux "$edition" "$version" "$checksum" "$checksum_type"
   else
-    log_error "This script only supports Ubuntu 16.04 and Amazon Linux 2."
+    log_error "This script only supports Ubuntu 16.04, 18.04, and Amazon Linux 2."
     exit 1
   fi
 

--- a/test/couchbase_multi_cluster_test.go
+++ b/test/couchbase_multi_cluster_test.go
@@ -1,22 +1,28 @@
 package test
 
 import (
-	"testing"
-	"path/filepath"
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/random"
+	"path/filepath"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const dataNodeClusterVarName = "couchbase_data_node_cluster_name"
 const indexQuerySearchClusterVarName = "couchbase_index_query_search_node_cluster_name"
 const syncGatewayClusterVarName = "sync_gateway_cluster_name"
 
-func TestIntegrationCouchbaseEnterpriseMultiClusterUbuntu(t *testing.T) {
+func TestIntegrationCouchbaseEnterpriseMultiClusterUbuntu16(t *testing.T) {
 	t.Parallel()
 	testCouchbaseMultiCluster(t, "ubuntu", "enterprise")
+}
+
+func TestIntegrationCouchbaseEnterpriseMultiClusterUbuntu18(t *testing.T) {
+	t.Parallel()
+	testCouchbaseMultiCluster(t, "ubuntu-18", "enterprise")
 }
 
 func TestIntegrationCouchbaseEnterpriseMultiClusterAmazonLinux(t *testing.T) {
@@ -65,11 +71,11 @@ func testCouchbaseMultiCluster(t *testing.T, osName string, edition string) {
 
 		terraformOptions := &terraform.Options{
 			TerraformDir: couchbaseMultiClusterDir,
-			Vars: map[string]interface{} {
+			Vars: map[string]interface{}{
 				"ami_id":                       amiId,
 				dataNodeClusterVarName:         formatCouchbaseClusterName("data", uniqueId),
 				indexQuerySearchClusterVarName: formatCouchbaseClusterName("search", uniqueId),
-				syncGatewayClusterVarName: 		formatCouchbaseClusterName("sync", uniqueId),
+				syncGatewayClusterVarName:      formatCouchbaseClusterName("sync", uniqueId),
 			},
 			EnvVars: map[string]string{
 				AWS_DEFAULT_REGION_ENV_VAR: awsRegion,
@@ -96,4 +102,3 @@ func testCouchbaseMultiCluster(t *testing.T, osName string, edition string) {
 		checkSyncGatewayWorking(t, syncGatewayUrl)
 	})
 }
-

--- a/test/couchbase_multi_datacenter_replication_test.go
+++ b/test/couchbase_multi_datacenter_replication_test.go
@@ -26,9 +26,14 @@ const savedUniqueIdReplica = "UniqueIdReplica"
 const providersFile = "providers.tf"
 const providersFileBackup = "providers.tf.bak"
 
-func TestIntegrationCouchbaseEnterpriseMultiDataCenterReplicationUbuntu(t *testing.T) {
+func TestIntegrationCouchbaseEnterpriseMultiDataCenterReplicationUbuntu16(t *testing.T) {
 	t.Parallel()
 	testCouchbaseMultiDataCenterReplication(t, "ubuntu", "enterprise")
+}
+
+func TestIntegrationCouchbaseEnterpriseMultiDataCenterReplicationUbuntu18(t *testing.T) {
+	t.Parallel()
+	testCouchbaseMultiDataCenterReplication(t, "ubuntu-18", "enterprise")
 }
 
 func TestIntegrationCouchbaseEnterpriseMultiDataCenterReplicationAmazonLinux(t *testing.T) {

--- a/test/couchbase_single_cluster_dns_tls_test.go
+++ b/test/couchbase_single_cluster_dns_tls_test.go
@@ -16,9 +16,14 @@ const domainNameForTest = "gruntwork.in"
 // filter them down to the real public hosted zone for domainNameForTest.
 var domainNameTags = map[string]string{"original": "true"}
 
-func TestIntegrationCouchbaseCommunitySingleClusterDnsTlsUbuntu(t *testing.T) {
+func TestIntegrationCouchbaseCommunitySingleClusterDnsTlsUbuntu16(t *testing.T) {
 	t.Parallel()
 	testCouchbaseSingleClusterDnsTls(t, "ubuntu", "community")
+}
+
+func TestIntegrationCouchbaseCommunitySingleClusterDnsTlsUbuntu18(t *testing.T) {
+	t.Parallel()
+	testCouchbaseSingleClusterDnsTls(t, "ubuntu-18", "community")
 }
 
 func testCouchbaseSingleClusterDnsTls(t *testing.T, osName string, edition string) {

--- a/test/couchbase_single_cluster_test.go
+++ b/test/couchbase_single_cluster_test.go
@@ -11,9 +11,14 @@ import (
 
 const couchbaseClusterVarName = "cluster_name"
 
-func TestIntegrationCouchbaseCommunitySingleClusterUbuntu(t *testing.T) {
+func TestIntegrationCouchbaseCommunitySingleClusterUbuntu16(t *testing.T) {
 	t.Parallel()
 	testCouchbaseSingleCluster(t, "ubuntu", "community")
+}
+
+func TestIntegrationCouchbaseCommunitySingleClusterUbuntu18(t *testing.T) {
+	t.Parallel()
+	testCouchbaseSingleCluster(t, "ubuntu-18", "community")
 }
 
 func TestIntegrationCouchbaseCommunitySingleClusterAmazonLinux(t *testing.T) {
@@ -21,9 +26,14 @@ func TestIntegrationCouchbaseCommunitySingleClusterAmazonLinux(t *testing.T) {
 	testCouchbaseSingleCluster(t, "amazon-linux", "community")
 }
 
-func TestIntegrationCouchbaseEnterpriseSingleClusterUbuntu(t *testing.T) {
+func TestIntegrationCouchbaseEnterpriseSingleClusterUbuntu16(t *testing.T) {
 	t.Parallel()
 	testCouchbaseSingleCluster(t, "ubuntu", "enterprise")
+}
+
+func TestIntegrationCouchbaseEnterpriseSingleClusterUbuntu18(t *testing.T) {
+	t.Parallel()
+	testCouchbaseSingleCluster(t, "ubuntu-18", "enterprise")
 }
 
 func TestIntegrationCouchbaseEnterpriseSingleClusterAmazonLinux(t *testing.T) {

--- a/test/docker_compose_test.go
+++ b/test/docker_compose_test.go
@@ -1,31 +1,33 @@
 package test
 
 import (
-	"testing"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
-	"os"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
-	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/logger"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/docker"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestUnitCouchbaseInDocker(t *testing.T) {
 	t.Parallel()
 
 	basicTestCases := []struct {
-		testName string
-		examplesFolderName string
-		osName string
-		edition string
-		clusterSize int
-		couchbaseWebConsolePort int
+		testName                  string
+		examplesFolderName        string
+		osName                    string
+		edition                   string
+		clusterSize               int
+		couchbaseWebConsolePort   int
 		syncGatewayWebConsolePort int
-	} {
-		{"TestUnitCouchbaseCommunitySingleClusterUbuntuInDocker","couchbase-cluster-simple", "ubuntu", "community", 2, 8091, 4984},
-		{"TestUnitCouchbaseEnterpriseMultiClusterAmazonLinuxInDocker", "couchbase-cluster-mds", "amazon-linux", "enterprise", 3,7091, 3984},
+	}{
+		{"TestUnitCouchbaseCommunitySingleClusterUbuntu16InDocker", "couchbase-cluster-simple", "ubuntu", "community", 2, 8091, 4984},
+		{"TestUnitCouchbaseCommunitySingleClusterUbuntu18InDocker", "couchbase-cluster-simple", "ubuntu-18", "community", 2, 8091, 4984},
+		{"TestUnitCouchbaseEnterpriseMultiClusterAmazonLinuxInDocker", "couchbase-cluster-mds", "amazon-linux", "enterprise", 3, 7091, 3984},
 	}
 
 	for _, testCase := range basicTestCases {
@@ -39,15 +41,16 @@ func TestUnitCouchbaseInDocker(t *testing.T) {
 	}
 
 	replicationTestCases := []struct {
-		testName string
-		examplesFolderName string
-		osName string
-		edition string
-		clusterSize int
+		testName                    string
+		examplesFolderName          string
+		osName                      string
+		edition                     string
+		clusterSize                 int
 		couchbaseWebConsolePortEast int
 		couchbaseWebConsolePortWest int
-	} {
-		{"TestUnitCouchbaseEnterpriseMultiDataCenterUbuntuInDocker", "couchbase-multi-datacenter-replication", "ubuntu", "enterprise", 2,6091, 5091},
+	}{
+		{"TestUnitCouchbaseEnterpriseMultiDataCenterUbuntu16InDocker", "couchbase-multi-datacenter-replication", "ubuntu", "enterprise", 2, 6091, 5091},
+		{"TestUnitCouchbaseEnterpriseMultiDataCenterUbuntu18InDocker", "couchbase-multi-datacenter-replication", "ubuntu-18", "enterprise", 2, 6091, 5091},
 	}
 
 	for _, testCase := range replicationTestCases {
@@ -70,10 +73,10 @@ func skipInCircleCi(t *testing.T) {
 func testCouchbaseInDockerBasic(t *testing.T, examplesFolderName string, osName string, edition string, clusterSize int, couchbaseWebConsolePort int, syncGatewayWebConsolePort int) {
 	uniqueId := random.UniqueId()
 	envVars := map[string]string{
-		"OS_NAME": osName,
+		"OS_NAME":             osName,
 		"CONTAINER_BASE_NAME": fmt.Sprintf("couchbase-%s", uniqueId),
-		"WEB_CONSOLE_PORT": strconv.Itoa(couchbaseWebConsolePort),
-		"SYNC_GATEWAY_PORT": strconv.Itoa(syncGatewayWebConsolePort),
+		"WEB_CONSOLE_PORT":    strconv.Itoa(couchbaseWebConsolePort),
+		"SYNC_GATEWAY_PORT":   strconv.Itoa(syncGatewayWebConsolePort),
 	}
 
 	tmpExamplesDir := test_structure.CopyTerraformFolderToTemp(t, "../", "examples")
@@ -81,7 +84,7 @@ func testCouchbaseInDockerBasic(t *testing.T, examplesFolderName string, osName 
 	couchbaseSingleClusterDockerDir := filepath.Join(tmpExamplesDir, examplesFolderName, "local-test")
 
 	test_structure.RunTestStage(t, "setup_image", func() {
-		buildCouchbaseWithPacker(t, fmt.Sprintf("%s-docker", osName), "couchbase","us-east-1", couchbaseAmiDir, edition)
+		buildCouchbaseWithPacker(t, fmt.Sprintf("%s-docker", osName), "couchbase", "us-east-1", couchbaseAmiDir, edition)
 	})
 
 	defer test_structure.RunTestStage(t, "teardown", func() {
@@ -109,8 +112,8 @@ func testCouchbaseInDockerBasic(t *testing.T, examplesFolderName string, osName 
 func testCouchbaseInDockerReplication(t *testing.T, examplesFolderName string, osName string, edition string, clusterSize int, couchbaseWebConsolePortEast int, couchbaseWebConsolePortWest int) {
 	uniqueId := random.UniqueId()
 	envVars := map[string]string{
-		"OS_NAME": osName,
-		"CONTAINER_BASE_NAME": fmt.Sprintf("couchbase-%s", uniqueId),
+		"OS_NAME":               osName,
+		"CONTAINER_BASE_NAME":   fmt.Sprintf("couchbase-%s", uniqueId),
 		"WEB_CONSOLE_EAST_PORT": strconv.Itoa(couchbaseWebConsolePortEast),
 		"WEB_CONSOLE_WEST_PORT": strconv.Itoa(couchbaseWebConsolePortWest),
 	}
@@ -120,7 +123,7 @@ func testCouchbaseInDockerReplication(t *testing.T, examplesFolderName string, o
 	couchbaseSingleClusterDockerDir := filepath.Join(tmpExamplesDir, examplesFolderName, "local-test")
 
 	test_structure.RunTestStage(t, "setup_image", func() {
-		buildCouchbaseWithPacker(t, fmt.Sprintf("%s-docker", osName), "couchbase","us-east-1", couchbaseAmiDir, edition)
+		buildCouchbaseWithPacker(t, fmt.Sprintf("%s-docker", osName), "couchbase", "us-east-1", couchbaseAmiDir, edition)
 	})
 
 	test_structure.RunTestStage(t, "setup_docker", func() {


### PR DESCRIPTION
This adds Ubuntu 18.04 to the examples and test to verify compatibility. Note that the install scripts needed some work to be compatible with Ubuntu 18.04.

### Controversial change

Couchbase does not provide dpkg artifacts for Ubuntu 18.04, except for the latest enterprise release. However, I found an article that suggests it will "just work" with the 16.04 artifact (https://linuxconfig.org/how-to-install-couchbase-server-on-ubuntu-18-04-bionic-beaver-linux), so decided to try it out and the tests actually passed, suggesting that it will work.

Therefore, I relaxed the constraint to the installer, and added fallback logic to use the 16.04 version if 18.04 artifact is not available from Couchbase.