### PR TITLE
Instance role options

### DIFF
--- a/examples/couchbase-ami/README.md
+++ b/examples/couchbase-ami/README.md
@@ -23,7 +23,7 @@ To build the Couchbase AMI:
 1. Configure your AWS credentials using one of the [options supported by the AWS 
    SDK](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). Usually, the easiest option is to
    set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-1. Update the `variables` section of the `couchbase.json` to specify the AWS region and Couchbase
+1. Update the `variables` section of the `couchbase.json` Packer template to specify the AWS region and Couchbase
    version you wish to use.
 1. To build an Ubuntu AMI for Couchbase Enterprise: `packer build -only=ubuntu-ami -var edition=enterprise couchbase.json`.
 1. To build an Ubuntu AMI for Couchbase Community: `packer build -only=ubuntu-ami -var edition=community couchbase.json`.

--- a/examples/couchbase-ami/README.md
+++ b/examples/couchbase-ami/README.md
@@ -23,7 +23,7 @@ To build the Couchbase AMI:
 1. Configure your AWS credentials using one of the [options supported by the AWS 
    SDK](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html). Usually, the easiest option is to
    set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables.
-1. Update the `variables` section of the `couchbase.json` Packer template to specify the AWS region and Couchbase
+1. Update the `variables` section of the `couchbase.json` to specify the AWS region and Couchbase
    version you wish to use.
 1. To build an Ubuntu AMI for Couchbase Enterprise: `packer build -only=ubuntu-ami -var edition=enterprise couchbase.json`.
 1. To build an Ubuntu AMI for Couchbase Community: `packer build -only=ubuntu-ami -var edition=community couchbase.json`.

--- a/modules/couchbase-cluster/main.tf
+++ b/modules/couchbase-cluster/main.tf
@@ -167,7 +167,7 @@ resource "aws_iam_instance_profile" "instance_profile" {
 resource "aws_iam_role" "instance_role" {
   name_prefix          = var.cluster_name
   assume_role_policy   = data.aws_iam_policy_document.instance_role.json
-  path                 = var.instance_profile_path
+  path                 = var.instance_role_path
   permissions_boundary = var.instance_permissions_boundary
 
   # aws_iam_instance_profile.instance_profile in this module sets create_before_destroy to true, which means

--- a/modules/couchbase-cluster/main.tf
+++ b/modules/couchbase-cluster/main.tf
@@ -165,8 +165,10 @@ resource "aws_iam_instance_profile" "instance_profile" {
 }
 
 resource "aws_iam_role" "instance_role" {
-  name_prefix        = var.cluster_name
-  assume_role_policy = data.aws_iam_policy_document.instance_role.json
+  name_prefix          = var.cluster_name
+  assume_role_policy   = data.aws_iam_policy_document.instance_role.json
+  path                 = var.instance_profile_path
+  permissions_boundary = var.instance_permissions_boundary
 
   # aws_iam_instance_profile.instance_profile in this module sets create_before_destroy to true, which means
   # everything it depends on, including this resource, must set it as well, or you'll get cyclic dependency errors

--- a/modules/couchbase-cluster/variables.tf
+++ b/modules/couchbase-cluster/variables.tf
@@ -164,6 +164,12 @@ variable "instance_profile_path" {
   default     = "/"
 }
 
+variable "instance_permissions_boundary" {
+  description = "The ARN of the policy that is used to set the permissions boundary for the instance profile role"
+  type        = string
+  default     = null
+}
+
 variable "ssh_port" {
   description = "The port used for SSH connections"
   type        = number

--- a/modules/couchbase-cluster/variables.tf
+++ b/modules/couchbase-cluster/variables.tf
@@ -164,6 +164,12 @@ variable "instance_profile_path" {
   default     = "/"
 }
 
+variable "instance_role_path" {
+  description = "Path in which to create the IAM instance role."
+  type        = string
+  default     = "/"
+}
+
 variable "instance_permissions_boundary" {
   description = "The ARN of the policy that is used to set the permissions boundary for the instance profile role"
   type        = string


### PR DESCRIPTION
Small typo fix in the README and add role path and permissions_boundary to the IAM instance role in cluster module.

I needed to be able to pass these in order to use the module so figured I would share the changes! I made a new variable for the instance role path in order to make this more backwards compatible, hopefully this change is ok.