### PR TITLE
Explicit dependency of the https_listener_ports templates on the list https_listener_ports_and_certs

### DIFF
--- a/modules/load-balancer/outputs.tf
+++ b/modules/load-balancer/outputs.tf
@@ -21,6 +21,15 @@ output "http_listener_arns" {
 data "template_file" "https_listener_ports" {
   count    = length(var.https_listener_ports_and_certs)
   template = var.https_listener_ports_and_certs[count.index]["port"]
+
+  # See https://github.com/gruntwork-io/terraform-aws-couchbase/pull/54
+  # In case the list https_listener_ports_and_certs is updated, terraform
+  # is somehow unable to see that the template file generation should
+  # be updated accordingly.
+  # This explicit "depends_on" ensures a proper dependency propagation.
+  depends_on = [
+    var.https_listener_ports_and_certs
+  ]
 }
 
 output "https_listener_arns" {
@@ -43,4 +52,3 @@ output "all_listener_arns" {
 output "security_group_id" {
   value = aws_security_group.sg.id
 }
-


### PR DESCRIPTION
As mentioned in https://github.com/gruntwork-io/terraform-aws-couchbase/issues/52 , terraform
seems to have trouble updating the template files if the upstream list https_listener_ports_and_certs
(used to generate the templates) changes.

This change states the dependency explicitely and fixes the issue: each time the list changes, the
templates are regenerated as well as all downstream dependencies.