### PR TITLE
Update repo to work with TF 0.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,11 @@ defaults: &defaults
     image: circleci/classic:201711-01
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.29
-    TERRATEST_LOG_PARSER_VERSION: v0.29.0
-    MODULE_CI_VERSION: v0.28.1
-    TERRAFORM_VERSION: 0.12.29
+    TERRATEST_LOG_PARSER_VERSION: v0.30.10
+    MODULE_CI_VERSION: v0.29.0
+    TERRAFORM_VERSION: 0.13.4
     TERRAGRUNT_VERSION: NONE
-    PACKER_VERSION: 1.4.1
+    PACKER_VERSION: 1.6.4
     GOLANG_VERSION: 1.14
 
 version: 2
@@ -23,19 +23,10 @@ jobs:
       - run: echo 'export PATH=$HOME/.local/bin:$HOME/terraform:$HOME/packer:$PATH' >> $BASH_ENV
 
       # Install Gruntwork and HashiCorp dependencies
-      - restore_cache:
-          keys:
-            - v2-external-dep
-      # Use the Gruntwork Installer to install the gruntwork-module-circleci-helpers
       - run: curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
       - run: gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
       - run: gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
       - run: configure-environment-for-gruntwork-module --terraform-version ${TERRAFORM_VERSION} --terragrunt-version ${TERRAGRUNT_VERSION} --packer-version ${PACKER_VERSION} --go-version ${GOLANG_VERSION}
-      - save_cache:
-          key: v2-external-dep
-          paths:
-            - $HOME/terraform
-            - $HOME/packer
 
       # Install external dependencies
       - run: DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install -y python-pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,6 @@
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.0.2
+    rev:  v0.1.10
     hooks:
       - id: terraform-fmt
+      - id: gofmt

--- a/examples/couchbase-cluster-mds/main.tf
+++ b/examples/couchbase-cluster-mds/main.tf
@@ -10,7 +10,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/couchbase-cluster-simple-dns-tls/main.tf
+++ b/examples/couchbase-cluster-simple-dns-tls/main.tf
@@ -12,7 +12,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/couchbase-multi-datacenter-replication/main.tf
+++ b/examples/couchbase-multi-datacenter-replication/main.tf
@@ -9,7 +9,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 provider "aws" {

--- a/main.tf
+++ b/main.tf
@@ -11,7 +11,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/couchbase-cluster/main.tf
+++ b/modules/couchbase-cluster/main.tf
@@ -4,7 +4,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/couchbase-iam-policies/main.tf
+++ b/modules/couchbase-iam-policies/main.tf
@@ -4,7 +4,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/couchbase-server-security-group-rules/main.tf
+++ b/modules/couchbase-server-security-group-rules/main.tf
@@ -4,7 +4,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/load-balancer-target-group/main.tf
+++ b/modules/load-balancer-target-group/main.tf
@@ -4,7 +4,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/load-balancer/main.tf
+++ b/modules/load-balancer/main.tf
@@ -4,7 +4,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/sync-gateway-security-group-rules/main.tf
+++ b/modules/sync-gateway-security-group-rules/main.tf
@@ -4,7 +4,10 @@
 # ----------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 0.12"
+  # This module is now only being tested with Terraform 0.13.x. However, to make upgrading easier, we are setting
+  # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
+  # forwards compatible with 0.13.x code.
+  required_version = ">= 0.12.26"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -1,16 +1,16 @@
 package test
 
 import (
-	"testing"
 	"fmt"
-	"time"
-	"net/http"
-	"net/url"
-	"io/ioutil"
-	"strings"
+	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/packer"
-	"github.com/gruntwork-io/terratest/modules/aws"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
 )
 
 // The username and password we use in all the examples, mocks, and tests
@@ -49,17 +49,16 @@ func buildCouchbaseWithPackerE(t *testing.T, builderName string, baseAmiName str
 
 	options := &packer.Options{
 		Template: templatePath,
-		Only: builderName,
+		Only:     builderName,
 		Vars: map[string]string{
-			"aws_region": awsRegion,
+			"aws_region":    awsRegion,
 			"base_ami_name": baseAmiName,
-			"edition": edition,
+			"edition":       edition,
 		},
 	}
 
 	return packer.BuildAmiE(t, options)
 }
-
 
 func HttpPostForm(t *testing.T, postUrl string, postParams url.Values) (int, string, error) {
 	logger.Logf(t, "Making an HTTP POST call to URL %s with body %v", postUrl, postParams)


### PR DESCRIPTION
1. Update `required_version` to `0.12.26` everywhere.
1. Add pre-commit hooks.
1. Update version numbers in CI build.
