### PR TITLE
Add Gruntwork AMI Publishing context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,3 +86,4 @@ workflows:
               ignore: /.*/
           context:
             - Gruntwork Admin
+            - Gruntwork AMI Publishing


### PR DESCRIPTION
The `release` job requires not only Phx DevOps creds, but also Gruntwork AMI Publishing creds. These both used to be specified via one-off env vars in the CircleCi build for this repo, but I've moved them to separate CircleCi contexts. See https://www.notion.so/gruntwork/CircleCi-Contexts-secrets-for-CI-eb83b438ad6646d78f6c6a8ffaca3c45#ddcf54d119dc455ab8fc2dc40f0d8290 for more info.