### PR TITLE
Fix for nitro ebs volumes

### DIFF
--- a/examples/couchbase-cluster-mds/main.tf
+++ b/examples/couchbase-cluster-mds/main.tf
@@ -45,7 +45,7 @@ module "couchbase_data_nodes" {
     {
       device_name = var.data_volume_device_name
       volume_type = "gp2"
-      volume_size = 50
+      volume_size = var.data_volume_size
     },
   ]
 
@@ -102,7 +102,7 @@ module "couchbase_index_query_search_nodes" {
     {
       device_name = var.index_volume_device_name
       volume_type = "gp2"
-      volume_size = 50
+      volume_size = var.index_volume_size
     },
   ]
 
@@ -192,6 +192,7 @@ data "template_file" "user_data_couchbase_data_nodes" {
     # Pass in the data about the EBS volumes so they can be mounted
     data_volume_device_name = var.data_volume_device_name
     data_volume_mount_point = var.data_volume_mount_point
+    data_volume_size        = var.data_volume_size
     volume_owner            = var.volume_owner
 
     # Use a small amount of memory so this example can fit on a t2.micro. In production settings, you'll want to run
@@ -212,6 +213,7 @@ data "template_file" "user_data_couchbase_index_query_search_nodes" {
     # Pass in the data about the EBS volumes so they can be mounted
     index_volume_device_name = var.index_volume_device_name
     index_volume_mount_point = var.index_volume_mount_point
+    index_volume_size        = var.index_volume_size
     volume_owner             = var.volume_owner
   }
 }

--- a/examples/couchbase-cluster-mds/user-data/user-data-couchbase-data-nodes.sh
+++ b/examples/couchbase-cluster-mds/user-data/user-data-couchbase-data-nodes.sh
@@ -12,10 +12,11 @@ source "/opt/couchbase-commons/mount-volume.sh"
 function mount_volumes {
   local readonly data_volume_device_name="$1"
   local readonly data_volume_mount_point="$2"
-  local readonly volume_owner="$3"
+  local readonly data_volume_size="$3"
+  local readonly volume_owner="$4"
 
   echo "Mounting EBS Volume for the data directory"
-  mount_volume "$data_volume_device_name" "$data_volume_mount_point" "$volume_owner"
+  mount_volume "$data_volume_device_name" "$data_volume_mount_point" "$data_volume_size" "$volume_owner"
 }
 
 function run_couchbase {
@@ -95,10 +96,11 @@ function run {
   local readonly cluster_port="$2"
   local readonly data_volume_device_name="$3"
   local readonly data_volume_mount_point="$4"
-  local readonly volume_owner="$5"
-  local readonly data_ramsize="$6"
-  local readonly index_ramsize="$7"
-  local readonly fts_ramsize="$8"
+  local readonly data_volume_size="$5"
+  local readonly volume_owner="$6"
+  local readonly data_ramsize="$7"
+  local readonly index_ramsize="$8"
+  local readonly fts_ramsize="$9"
 
   # To keep this example simple, we are hard-coding all credentials in this file in plain text. You should NOT do this
   # in production usage!!! Instead, you should use tools such as Vault, Keywhiz, or KMS to fetch the credentials at
@@ -106,7 +108,7 @@ function run {
   local readonly cluster_username="admin"
   local readonly cluster_password="password"
 
-  mount_volumes "$data_volume_device_name" "$data_volume_mount_point" "$volume_owner"
+  mount_volumes "$data_volume_device_name" "$data_volume_mount_point" "$data_volume_size" "$volume_owner"
   run_couchbase "$cluster_asg_name" "$cluster_username" "$cluster_password" "$cluster_port" "$data_volume_mount_point" "$data_ramsize" "$index_ramsize" "$fts_ramsize"
 
   local node_hostname
@@ -133,6 +135,7 @@ run \
   "${cluster_port}" \
   "${data_volume_device_name}" \
   "${data_volume_mount_point}" \
+  "${data_volume_size}" \
   "${volume_owner}" \
   "${data_ramsize}" \
   "${index_ramsize}" \

--- a/examples/couchbase-cluster-mds/user-data/user-data-couchbase-index-query-search-nodes.sh
+++ b/examples/couchbase-cluster-mds/user-data/user-data-couchbase-index-query-search-nodes.sh
@@ -11,10 +11,11 @@ source "/opt/couchbase-commons/mount-volume.sh"
 function mount_volumes {
   local readonly index_volume_device_name="$1"
   local readonly index_volume_mount_point="$2"
-  local readonly volume_owner="$3"
+  local readonly index_volume_size="$3"
+  local readonly volume_owner="$4"
 
   echo "Mounting EBS Volume for the index directory"
-  mount_volume "$index_volume_device_name" "$index_volume_mount_point" "$volume_owner"
+  mount_volume "$index_volume_device_name" "$index_volume_mount_point" "$index_volume_size" "$volume_owner"
 }
 
 function run_couchbase {
@@ -41,7 +42,8 @@ function run {
   local readonly cluster_port="$2"
   local readonly index_volume_device_name="$3"
   local readonly index_volume_mount_point="$4"
-  local readonly volume_owner="$5"
+  local readonly index_volume_size="$5"
+  local readonly volume_owner="$6"
 
   # To keep this example simple, we are hard-coding all credentials in this file in plain text. You should NOT do this
   # in production usage!!! Instead, you should use tools such as Vault, Keywhiz, or KMS to fetch the credentials at
@@ -49,7 +51,7 @@ function run {
   local readonly cluster_username="admin"
   local readonly cluster_password="password"
 
-  mount_volumes "$index_volume_device_name" "$index_volume_mount_point" "$volume_owner"
+  mount_volumes "$index_volume_device_name" "$index_volume_mount_point" "$index_volume_size" "$volume_owner"
   run_couchbase "$cluster_asg_name" "$cluster_username" "$cluster_password" "$cluster_port" "$index_volume_mount_point"
 }
 
@@ -59,5 +61,6 @@ run \
   "${cluster_port}" \
   "${index_volume_device_name}" \
   "${index_volume_mount_point}" \
+  "${index_volume_size}" \
   "${volume_owner}"
 

--- a/examples/couchbase-cluster-mds/variables.tf
+++ b/examples/couchbase-cluster-mds/variables.tf
@@ -59,6 +59,12 @@ variable "data_volume_mount_point" {
   default     = "/couchbase-data"
 }
 
+variable "data_volume_size" {
+  description = "The data node ebs volume size"
+  type        = number
+  default     = 200
+}
+
 variable "index_volume_device_name" {
   description = "The device name to use for the EBS Volume used for the index directory on Couchbase nodes."
   type        = string
@@ -69,6 +75,12 @@ variable "index_volume_mount_point" {
   description = "The mount point (folder path) to use for the EBS Volume used for the index directory on Couchbase nodes."
   type        = string
   default     = "/couchbase-index"
+}
+
+variable "index_volume_size" {
+  description = "The search/index node ebs volume size. When using nitro based instance types this size needs to be unique"
+  type        = number
+  default     = 53
 }
 
 variable "volume_owner" {

--- a/modules/couchbase-commons/mount-volume.sh
+++ b/modules/couchbase-commons/mount-volume.sh
@@ -8,12 +8,25 @@ source "/opt/gruntwork/bash-commons/log.sh"
 # This method is used to configure a new EBS volume. It formats the specified device name using ext4 and mounts it at
 # the given mount point, with the given OS user as owner.
 function mount_volume {
-  local readonly device_name="$1"
+  local device_name="$1"
   local readonly mount_point="$2"
+  local readonly ebs_size="$3"
   local readonly owner="$3"
   local readonly file_system_type="${4:-ext4}"
   local readonly mount_options="${5:-defaults,nofail}"
   local readonly fs_tab_path="/etc/fstab"
+
+  # check if the expected device name exists
+  # if not, likely is a nitro based instance and need to get the nvmeXn1 device name
+  if [ ! -e $device_name ]; then
+    log_info "Device not found with name '$device_name' looking up by size '${ebs_size}'"
+    disk_name=`lsblk -do NAME,SIZE | grep ${ebs_size}G | cut -d ' ' -f 1`
+    if [[ "$disk_name" == nvme* ]]; then
+      ebs_device_name="/dev/${disk_name}"
+      log_info "Update device_name with '$ebs_device_name'"
+      device_name=$ebs_device_name
+    fi
+  fi
 
   case "$file_system_type" in
     "ext4")

--- a/modules/couchbase-commons/mount-volume.sh
+++ b/modules/couchbase-commons/mount-volume.sh
@@ -11,9 +11,9 @@ function mount_volume {
   local device_name="$1"
   local readonly mount_point="$2"
   local readonly ebs_size="$3"
-  local readonly owner="$3"
-  local readonly file_system_type="${4:-ext4}"
-  local readonly mount_options="${5:-defaults,nofail}"
+  local readonly owner="$4"
+  local readonly file_system_type="${5:-ext4}"
+  local readonly mount_options="${6:-defaults,nofail}"
   local readonly fs_tab_path="/etc/fstab"
 
   # check if the expected device name exists

--- a/modules/couchbase-commons/mount-volume.sh
+++ b/modules/couchbase-commons/mount-volume.sh
@@ -8,34 +8,35 @@ source "/opt/gruntwork/bash-commons/log.sh"
 # This method is used to configure a new EBS volume. It formats the specified device name using ext4 and mounts it at
 # the given mount point, with the given OS user as owner.
 function mount_volume {
-  local device_name="$1"
+  local readonly device_name="$1"
   local readonly mount_point="$2"
   local readonly ebs_size="$3"
   local readonly owner="$4"
   local readonly file_system_type="${5:-ext4}"
   local readonly mount_options="${6:-defaults,nofail}"
   local readonly fs_tab_path="/etc/fstab"
+  local device_path="/dev/${device_name}"
 
   # check if the expected device name exists
   # if not, likely is a nitro based instance and need to get the nvmeXn1 device name
-  if [ ! -e $device_name ]; then
-    log_info "Device not found with name '$device_name' looking up by size '${ebs_size}'"
+  if [ ! -e $device_path ]; then
+    log_info "Device not found with name '${device_name}' looking up by size '${ebs_size}'"
     disk_name=`lsblk -do NAME,SIZE | grep ${ebs_size}G | cut -d ' ' -f 1`
     if [[ "$disk_name" == nvme* ]]; then
       ebs_device_name="/dev/${disk_name}"
-      log_info "Update device_name with '$ebs_device_name'"
-      device_name=$ebs_device_name
+      log_info "Update device_path with '${ebs_device_name}'"
+      device_path=$ebs_device_name
     fi
   fi
 
   case "$file_system_type" in
     "ext4")
-      log_info "Creating $file_system_type file system on $device_name..."
-      mkfs.ext4 -F "$device_name"
+      log_info "Creating $file_system_type file system on $device_path..."
+      mkfs.ext4 -F "$device_path"
       ;;
     "xfs")
-      log_info "Creating $file_system_type file system on $device_name..."
-      mkfs.xfs -f "$device_name"
+      log_info "Creating $file_system_type file system on $device_path..."
+      mkfs.xfs -f "$device_path"
       ;;
     *)
       log_error "The file system type '$file_system_type' is not currently supported by this script."
@@ -46,7 +47,7 @@ function mount_volume {
   mkdir "$mount_point"
 
   log_info "Adding device $device_name to $fs_tab_path with mount point $mount_point..."
-  echo "$device_name       $mount_point   $file_system_type    $mount_options  0 2" >> "$fs_tab_path"
+  echo "$device_path       $mount_point   $file_system_type    $mount_options  0 2" >> "$fs_tab_path"
 
   log_info "Mounting volumes..."
   mount -a


### PR DESCRIPTION
This is a simple fix for issue #73 

The mount_volume shell script in modules/couchbase-commons fails when the ec2 instance is based on nitro hypervisor.

This simple fix expects a unique ebs volume size, eg. 46731. It then finds the device name from `lsblk`.

I'm using this in our cluster but haven't run the tests.