### PR TITLE
fix for jq error on backticks

### DIFF
--- a/modules/run-sync-gateway/run-sync-gateway
+++ b/modules/run-sync-gateway/run-sync-gateway
@@ -182,7 +182,7 @@ function wait_for_couchbase_clusters {
   fi
 
   local databases
-  databases=($(cat "$config" | jq -c '.databases | .[]?'))
+  databases=($(cat "$config"| sed '/"import_filter": `/,/`/d' | sed '/"sync": `/,/`/d' | sed 's/"num_index_replicas": 0,/"num_index_replicas": 0/g' | jq -c '.databases | .[]?'))
 
   if [[ -z "${databases[@]}" ]]; then
     log_warn "No databases found in $config. Nothing to wait for."


### PR DESCRIPTION
This is a simple fix for issue #74 

JQ doesn't handle backticks in JSON so sync_gateway fails to start. This update removes the `import_filter` and `sync` properties from the database keys in the string so the script can properly wait for the cluster and buckets to be ready.

Only tested on my cluster.