### PR TITLE
[IAC-1677] Replace gofmt with goimports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
       - run:
           command: |
             pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0 yapf
+            go get golang.org/x/tools/cmd/goimports
+            export GOPATH=~/go/bin && export PATH=$PATH:$GOPATH 
             pre-commit install
             pre-commit run --all-files
   test:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev:  v0.1.10
     hooks:
       - id: terraform-fmt
-      - id: gofmt
+      - id: goimports

--- a/test/couchbase_multi_cluster_test.go
+++ b/test/couchbase_multi_cluster_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/aws"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const dataNodeClusterVarName = "couchbase_data_node_cluster_name"

--- a/test/couchbase_multi_datacenter_replication_test.go
+++ b/test/couchbase_multi_datacenter_replication_test.go
@@ -2,13 +2,14 @@ package test
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/aws"
-	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
 	"path/filepath"
 	"sync"
 	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/random"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const clusterNamePrimaryVarName = "cluster_name_primary"

--- a/test/docker_compose_test.go
+++ b/test/docker_compose_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/docker"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestUnitCouchbaseInDocker(t *testing.T) {

--- a/test/terratest_helpers.go
+++ b/test/terratest_helpers.go
@@ -2,15 +2,16 @@ package test
 
 import (
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/aws"
-	"github.com/gruntwork-io/terratest/modules/logger"
-	"github.com/gruntwork-io/terratest/modules/packer"
 	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/packer"
 )
 
 // The username and password we use in all the examples, mocks, and tests


### PR DESCRIPTION
Replace gofmt with goimports in the pre-commit configuration. Note: This PR was opened using git-xargs.