### PR TITLE
Data source: use aws_subnets over aws_subnet_ids

### DIFF
--- a/examples/couchbase-cluster-mds/main.tf
+++ b/examples/couchbase-cluster-mds/main.tf
@@ -33,7 +33,7 @@ module "couchbase_data_nodes" {
   user_data = data.template_file.user_data_couchbase_data_nodes.rendered
 
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = data.aws_subnets.default.ids
 
   # We recommend using a separate EBS Volumes for the Couchbase data dir
   ebs_block_devices = [
@@ -90,7 +90,7 @@ module "couchbase_index_query_search_nodes" {
   user_data = data.template_file.user_data_couchbase_index_query_search_nodes.rendered
 
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = data.aws_subnets.default.ids
 
   # We recommend using a separate EBS Volumes for the Couchbase index dir
   ebs_block_devices = [
@@ -147,7 +147,7 @@ module "sync_gateway" {
   user_data = data.template_file.user_data_sync_gateway.rendered
 
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = data.aws_subnets.default.ids
 
   # To make testing easier, we allow SSH requests from any IP address here. In a production deployment, we strongly
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
@@ -240,7 +240,7 @@ module "load_balancer" {
 
   name       = var.couchbase_data_node_cluster_name
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = data.aws_subnets.default.ids
 
   http_listener_ports            = [var.data_nodes_load_balancer_port, var.index_query_search_nodes_load_balancer_port, var.sync_gateway_load_balancer_port]
   https_listener_ports_and_certs = []
@@ -488,7 +488,10 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "default" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 

--- a/examples/couchbase-cluster-simple-dns-tls/main.tf
+++ b/examples/couchbase-cluster-simple-dns-tls/main.tf
@@ -32,7 +32,7 @@ module "couchbase" {
   user_data = data.template_file.user_data_server.rendered
 
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = data.aws_subnets.default.ids
 
   # We recommend using two EBS Volumes with your Couchbase servers: one for the data directory and one for the index
   # directory.
@@ -115,7 +115,7 @@ module "load_balancer" {
 
   name       = var.cluster_name
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = data.aws_subnets.default.ids
 
   # In this example, we only listen for HTTPS requests on the load balancer
 
@@ -256,8 +256,11 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "default" {
-  vpc_id = data.aws_vpc.default.id
+data "aws_subnets" "default" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default.id]
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/examples/couchbase-multi-datacenter-replication/main.tf
+++ b/examples/couchbase-multi-datacenter-replication/main.tf
@@ -39,7 +39,7 @@ module "couchbase_primary" {
   user_data = data.template_file.user_data_primary.rendered
 
   vpc_id     = data.aws_vpc.default_primary.id
-  subnet_ids = data.aws_subnet_ids.default_primary.ids
+  subnet_ids = data.aws_subnets.default_primary.ids
 
   # To make testing easier, we allow SSH requests from any IP address here. In a production deployment, we strongly
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
@@ -79,7 +79,7 @@ module "couchbase_replica" {
   user_data = data.template_file.user_data_replica.rendered
 
   vpc_id     = data.aws_vpc.default_replica.id
-  subnet_ids = data.aws_subnet_ids.default_replica.ids
+  subnet_ids = data.aws_subnets.default_replica.ids
 
   # To make testing easier, we allow SSH requests from any IP address here. In a production deployment, we strongly
   # recommend you limit this to the IP address ranges of known, trusted servers inside your VPC.
@@ -144,7 +144,7 @@ module "load_balancer_primary" {
 
   name       = var.cluster_name_primary
   vpc_id     = data.aws_vpc.default_primary.id
-  subnet_ids = data.aws_subnet_ids.default_primary.ids
+  subnet_ids = data.aws_subnets.default_primary.ids
 
   http_listener_ports            = [var.couchbase_load_balancer_port]
   https_listener_ports_and_certs = []
@@ -199,7 +199,7 @@ module "load_balancer_replica" {
 
   name       = var.cluster_name_replica
   vpc_id     = data.aws_vpc.default_replica.id
-  subnet_ids = data.aws_subnet_ids.default_replica.ids
+  subnet_ids = data.aws_subnets.default_replica.ids
 
   http_listener_ports            = [var.couchbase_load_balancer_port]
   https_listener_ports_and_certs = []
@@ -411,10 +411,13 @@ data "aws_vpc" "default_primary" {
   provider = aws.primary
 }
 
-data "aws_subnet_ids" "default_primary" {
-  vpc_id = data.aws_vpc.default_primary.id
+data "aws_subnets" "default_primary" {
 
   provider = aws.primary
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default_primary.id]
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -430,10 +433,13 @@ data "aws_vpc" "default_replica" {
   provider = aws.replica
 }
 
-data "aws_subnet_ids" "default_replica" {
-  vpc_id = data.aws_vpc.default_replica.id
+data "aws_subnets" "default_replica" {
 
   provider = aws.replica
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.default_replica.id]
+  }
 }
 
 data "aws_region" "replica" {

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ module "couchbase" {
   user_data = data.template_file.user_data_server.rendered
 
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = data.aws_subnets.default.ids
 
   # We recommend using two EBS Volumes with your Couchbase servers: one for the data directory and one for the index
   # directory.
@@ -114,7 +114,7 @@ module "load_balancer" {
 
   name       = var.cluster_name
   vpc_id     = data.aws_vpc.default.id
-  subnet_ids = data.aws_subnet_ids.default.ids
+  subnet_ids = data.aws_subnets.default.ids
 
   http_listener_ports            = [var.couchbase_load_balancer_port, var.sync_gateway_load_balancer_port]
   https_listener_ports_and_certs = []
@@ -270,7 +270,7 @@ data "aws_vpc" "default" {
   default = true
 }
 
-data "aws_subnet_ids" "default" {
+data "aws_subnets" "default" {
   vpc_id = data.aws_vpc.default.id
 }
 


### PR DESCRIPTION
## Description

Addresses _internal_ aws v4 compatibility.

This updates example code only. The provider version handles both old and new data sources, so users have no updates to make on their end as a result of this change. It is backward compatible. When we bump the provider version to at least 3.75 _and/or_ remove the 4.x lock, that's when we have a potential backward incompatibility, but most likely, even that update will be functionally backward compatible, i.e., only require an update to the provider version, and no config changes, imports, or state migrations.

### Documentation

N/A

## TODOs

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backwards compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
- ~Ensure any 3rd party code adheres with our license policy: https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378~
- [ ] _Maintainers Only._ If necessary, release a new version of this repo.
- ~_Maintainers Only._ If there were backwards incompatible changes, include a migration guide in the release notes.~
- [ ] _Maintainers Only._ Add to the next version of the monthly newsletter (see https://www.notion.so/gruntwork/Monthly-Newsletter-9198cbe7f8914d4abce23dca7b435f43).


## Related Issues
Addresses https://github.com/gruntwork-io/cloud-chasers/issues/20
