### PR TITLE
Cluster Admin credentials as module variables 

### DIFF
--- a/examples/couchbase-cluster-simple/user-data/user-data.sh
+++ b/examples/couchbase-cluster-simple/user-data/user-data.sh
@@ -119,12 +119,13 @@ function run {
   local readonly index_volume_device_name="$7"
   local readonly index_volume_mount_point="$8"
   local readonly volume_owner="$9"
+  local readonly cluster_username="$10"
+  local readonly cluster_password="$11"
+
 
   # To keep this example simple, we are hard-coding all credentials in this file in plain text. You should NOT do this
   # in production usage!!! Instead, you should use tools such as Vault, Keywhiz, or KMS to fetch the credentials at
   # runtime and only ever have the plaintext version in memory.
-  local readonly cluster_username="admin"
-  local readonly cluster_password="password"
   local readonly test_user_name="test-user"
   local readonly test_user_password="password"
   local readonly test_bucket_name="test-bucket"
@@ -155,4 +156,6 @@ run \
   "${index_volume_device_name}" \
   "${index_volume_mount_point}" \
   "${volume_owner}"
+  "${cluster_username}"
+  "${cluster_password}"
 

--- a/main.tf
+++ b/main.tf
@@ -85,6 +85,8 @@ data "template_file" "user_data_server" {
   vars = {
     cluster_asg_name = var.cluster_name
     cluster_port     = module.couchbase_security_group_rules.rest_port
+    cluster_username = var.cluster_username
+    cluster_password = var.cluster_password
 
     # We expose the Sync Gateway on all IPs but the Sync Gateway Admin should ONLY be accessible from localhost, as it
     # provides admin access to ALL Sync Gateway data.

--- a/variables.tf
+++ b/variables.tf
@@ -77,3 +77,15 @@ variable "sync_gateway_load_balancer_port" {
   default     = 4984
 }
 
+variable "cluster_username" {
+  description = "What is the user name of this cluster admin"
+  type        = string
+  default     = "admin"
+}
+
+variable "cluster_password" {
+  description = "What is the password of the cluster admin"
+  type        = string
+  default     = "password"
+}
+


### PR DESCRIPTION
Allow the Cluster Admin User Name and Password to be provided at the run time. 